### PR TITLE
Fixes

### DIFF
--- a/IBKit/Event/EventViewController.m
+++ b/IBKit/Event/EventViewController.m
@@ -417,14 +417,15 @@
                 }
             }
             else {
+                BOOL isOnStageUser = [isWith isEqualToString:@"fan"] || [isWith isEqualToString:@"celebrity"] || [isWith isEqualToString:@"host"];
                 // Unsubscribe audio only from the user in the private call with the producer and only if he or she is the stage fan, celebrity or host
-                if ([isWith isEqualToString:@"fan"] || [isWith isEqualToString:@"celebrity"] || [isWith isEqualToString:@"host"]) {
+                if (isOnStageUser) {
                     OTSubscriber *subscriber = self.openTokManager.subscribers[isWith];
                     if (subscriber) {
                         subscriber.subscribeToAudio = NO;
                     }
                 }
-                if (self.user.status == IBUserStatusOnstage) {
+                if (self.user.status == IBUserStatusOnstage && isOnStageUser) {
                     [self.eventView showNotification:@"OTHER PARTICIPANTS ARE IN A PRIVATE CALL. THEY MAY NOT BE ABLE TO HEAR YOU." useColor:[UIColor SLBlueColor]];
                 }
             }


### PR DESCRIPTION
This PR fixes the following issues:
1) The iOS Fan is in backstage, and the producer starts a private call with any other user (fans, host or celebrity) the message "OTHER PARTICIPANTS ARE IN A PRIVATE CALL. THEY MAY NOT BE ABLE TO HEAR YOU." was being displayed incorrectly. This should be only displayed only if the ios fan is on stage, and the user called is the host or celebrity.
2) If i'm the fan in the line, When the producer starts a private call with anybody different than me, I'm muting to all the subscribers. I just need to mute the user being called by the producer.
3) If i'm the fan on stage and the event is on preshow, when the producer starts a private call with me I see the publisher preview. This should only happen if I'm on backstage or just in the line.